### PR TITLE
improved stability, provide exit clause, catch wikipedia exception

### DIFF
--- a/jarvis.py
+++ b/jarvis.py
@@ -4,11 +4,16 @@ import pywhatkit
 import datetime
 import wikipedia
 import pyjokes
+import traceback
 
 listener = sr.Recognizer()
 engine = pyttsx3.init()
 voices = engine.getProperty('voices')
 engine.setProperty('voice', voices[1].id)
+
+class status:
+    isRunning = True
+    engineUsed = ""
 
 
 def talk(text):
@@ -17,6 +22,7 @@ def talk(text):
 
 
 def take_command():
+    command = ""
     try:
         with sr.Microphone() as source:
             print('listening...')
@@ -32,12 +38,12 @@ def take_command():
 
 
 def run_jarvis():
-
     command = take_command()
     print(command)
 
     if 'play' in command:
         song = command.replace('play', '')
+        status.engineUsed = "YouTube"
         talk('playing ' + song)
         pywhatkit.playonyt(song)
 
@@ -47,24 +53,28 @@ def run_jarvis():
 
     elif 'who' in command:
         person = command.replace('who', '')
+        status.engineUsed = "wikipedia"
         info = wikipedia.summary(person, 1)
         print(info)
         talk(info)
 
     elif 'what' in command:
         person = command.replace('what', '')
+        status.engineUsed = "wikipedia"
         info = wikipedia.summary(person, 1)
         print(info)
         talk(info)
 
     elif 'when' in command:
         person = command.replace('when', '')
+        status.engineUsed = "wikipedia"
         info = wikipedia.summary(person, 1)
         print(info)
         talk(info)
 
     elif 'where' in command:
         person = command.replace('where', '')
+        status.engineUsed = "wikipedia"
         info = wikipedia.summary(person, 1)
         print(info)
         talk(info)
@@ -76,10 +86,19 @@ def run_jarvis():
         talk('No, I am in a relationship with wifi')
 
     elif 'joke' in command:
+        status.engineUsed = "pyjokes"
         talk(pyjokes.get_joke())
 
+    elif 'stop listening'.__eq__(command):
+        talk('Bye, until next time.')
+        status.isRunning = False
     else:
         talk('Sorry but I did not understand')
 
-while True:
-    run_jarvis()
+while status.isRunning:
+    print("...")# without it, it didn't stop listening
+    try:
+        run_jarvis()
+    except Exception as e:
+        talk(f"Sorry, {status.engineUsed} could not find this.") 
+        print(e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyttsx3==2.90
 pywhatkit==5.4
 wikipedia==1.4.0
 SpeechRecognition==3.10.4
+PyAudio==0.2.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pyjokes==0.6.0
+pyttsx3==2.90
+pywhatkit==5.4
+wikipedia==1.4.0
+SpeechRecognition==3.10.4


### PR DESCRIPTION
* added requirements.txt
* Now you can say "stop listening" to quit jarvis without manually closing the shell window. To do this I added a loop status variable.
* Try something that wikipedia does not manage to look up, for example "when tom petty": wikipedia.summary() raises an exception and let the application quit;
 this exception is now caught down in the while loop.
